### PR TITLE
Fix demo data

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+dataset-uploads/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # Project-specific
 
 assets/bundles/
+dataset-uploads/
 
 #=====================================================================
 # Django-specific

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ install:
 script:
   - docker-compose run --rm web yarn build
   - docker-compose run --rm web python manage.py collectstatic --no-input
-  - docker-compose run --rm web bin/wait-for-postgres.sh coverage run --source=procurement_portal manage.py test
+  - docker-compose run --rm web bin/wait-for-postgres.sh manage.py migrate
+  - docker-compose run --rm web loaddata demodata
+  - docker-compose run --rm web coverage run --source=procurement_portal manage.py test
 
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ install:
 script:
   - docker-compose run --rm web yarn build
   - docker-compose run --rm web python manage.py collectstatic --no-input
-  - docker-compose run --rm web bin/wait-for-postgres.sh manage.py migrate
-  - docker-compose run --rm web loaddata demodata
+  - docker-compose run --rm web bin/wait-for-postgres.sh python manage.py migrate
+  - docker-compose run --rm web python manage.py loaddata demodata
   - docker-compose run --rm web coverage run --source=procurement_portal manage.py test
 
 

--- a/app.json
+++ b/app.json
@@ -4,8 +4,7 @@
     "review": {
       "addons": ["heroku-postgresql:hobby-dev"],
       "env": {
-        "TAG_MANAGER_ENABLED": "False",
-        "DEFAULT_FILE_STORAGE": "django.core.files.storage.FileSystemStorage"
+        "TAG_MANAGER_ENABLED": "False"
       },
       "scripts": {
         "release": "python manage.py flush --no-input && python manage.py migrate && python manage.py loaddata demodata"
@@ -14,8 +13,7 @@
     "staging": {
       "addons": ["heroku-postgresql:hobby-dev"],
       "env": {
-        "TAG_MANAGER_ENABLED": "False",
-        "DEFAULT_FILE_STORAGE": "django.core.files.storage.FileSystemStorage"
+        "TAG_MANAGER_ENABLED": "False"
       },
       "scripts": {
         "release": "python manage.py flush --no-input && python manage.py migrate && python manage.py loaddata demodata"

--- a/demodata.json
+++ b/demodata.json
@@ -87,7 +87,6 @@
 },
 {
   "model": "records.purchaserecord",
-  "pk": 1,
   "fields": {
     "created": "2020-09-19T18:41:15.072Z",
     "modified": "2020-09-19T18:41:15.072Z",
@@ -113,7 +112,6 @@
 },
 {
   "model": "records.purchaserecord",
-  "pk": 2,
   "fields": {
     "created": "2020-09-19T18:41:15.073Z",
     "modified": "2020-09-19T18:41:15.073Z",
@@ -139,7 +137,6 @@
 },
 {
   "model": "records.purchaserecord",
-  "pk": 3,
   "fields": {
     "created": "2020-09-19T18:43:05.075Z",
     "modified": "2020-09-19T18:43:05.075Z",
@@ -165,7 +162,6 @@
 },
 {
   "model": "records.purchaserecord",
-  "pk": 4,
   "fields": {
     "created": "2020-09-19T18:43:05.075Z",
     "modified": "2020-09-19T18:43:05.075Z",
@@ -191,7 +187,6 @@
 },
 {
   "model": "records.purchaserecord",
-  "pk": 5,
   "fields": {
     "created": "2020-09-19T18:44:16.015Z",
     "modified": "2020-09-19T18:44:16.015Z",
@@ -217,7 +212,6 @@
 },
 {
   "model": "records.purchaserecord",
-  "pk": 6,
   "fields": {
     "created": "2020-09-19T18:44:16.015Z",
     "modified": "2020-09-19T18:44:16.015Z",
@@ -243,7 +237,6 @@
 },
 {
   "model": "records.purchaserecord",
-  "pk": 7,
   "fields": {
     "created": "2020-09-19T18:44:16.016Z",
     "modified": "2020-09-19T18:44:16.016Z",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@ services:
     command: ./manage.py runserver 0.0.0.0:8000
     depends_on:
       - db
-      - minio-client
-      - minio
     environment:
       - DATABASE_URL=postgresql://procurement_portal:devpassword@db/procurement_portal
       - DJANGO_DEBUG=True
@@ -25,12 +23,6 @@ services:
       - DJANGO_SECRET_KEY=not-secret-in-dev
       - DJANGO_WHITENOISE_AUTOREFRESH=True
       - TAG_MANAGER_ENABLED=False
-      - AWS_ACCESS_KEY_ID=minio-access-key
-      - AWS_SECRET_ACCESS_KEY=minio-secret-key
-      - AWS_STORAGE_BUCKET_NAME=procurement-portal-storage
-      - AWS_S3_ENDPOINT_URL=http://minio:9000
-      - AWS_S3_SECURE_URLS=True
-      - AWS_S3_CUSTOM_DOMAIN
 
   db:
     image: postgres:11.6
@@ -41,33 +33,5 @@ services:
     volumes:
       - db-data:/var/lib/postgresql/data
 
-  minio:
-    image: "minio/minio:RELEASE.2019-10-12T01-39-57Z"
-    volumes:
-      - minio-data:/data
-    ports:
-      - "9000:9000"
-    environment:
-      - MINIO_ACCESS_KEY=minio-access-key
-      - MINIO_SECRET_KEY=minio-secret-key
-      - MINIO_DOMAIN=minio
-    command: minio --compat server data
-
-  minio-client:
-    image: "minio/mc:RELEASE.2019-12-17T23-26-28Z"
-    depends_on:
-      - minio
-    environment:
-      - MINIO_ACCESS_KEY=minio-access-key
-      - MINIO_SECRET_KEY=minio-secret-key
-      - MINIO_DOMAIN=minio
-    entrypoint: >
-      /bin/sh -c "
-      /usr/bin/mc config host add --quiet --api s3v4 local http://minio:9000 minio-access-key minio-secret-key;
-      /usr/bin/mc mb  local/procurement-portal-storage;
-      /usr/bin/mc policy set public local/procurement-portal-storage;
-      "
-
 volumes:
   db-data:
-  minio-data:

--- a/procurement_portal/settings.py
+++ b/procurement_portal/settings.py
@@ -165,7 +165,7 @@ if TAG_MANAGER_ENABLED:
     TAG_MANAGER_CONTAINER_ID = env("TAG_MANAGER_CONTAINER_ID")
 
 
-DEFAULT_FILE_STORAGE = env.str("DEFAULT_FILE_STORAGE", "storages.backends.s3boto3.S3Boto3Storage")
+DEFAULT_FILE_STORAGE = env.str("DEFAULT_FILE_STORAGE", "django.core.files.storage.FileSystemStorage")
 if DEFAULT_FILE_STORAGE == "storages.backends.s3boto3.S3Boto3Storage":
     AWS_ACCESS_KEY_ID = env.str("AWS_ACCESS_KEY_ID")
     AWS_SECRET_ACCESS_KEY = env.str("AWS_SECRET_ACCESS_KEY")


### PR DESCRIPTION
Fix demodata fixture not finding files, and duplicate key violating unique constraint.

- Use standard django file backend by default
- Make git and docker build ignore that directory, but the .:/app volume will make it available to the container in dev

Currently broken with:
```
  File "/usr/local/lib/python3.8/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
django.db.utils.IntegrityError: Problem installing fixture '/app/demodata.json': Could not load records.DatasetVersion(pk=1): duplicate key value violates unique constraint "records_purchaserecord_pkey"
DETAIL:  Key (id)=(1) already exists.
```