### PR TITLE
.dockerignore allow list for smaller images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,6 @@
 !manage.py
 !package.json
 !poetry.lock
-!procurement_portal
+!procurement_portal/
 !pyproject.toml
 !yarn.lock

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,17 @@
-dataset-uploads/
+# Don't put unnecessary stuff in the image
+
+# Ignore everything by default
+*
+
+# Explicitly add certain files and directories
+!LICENSE
+!README.md
+!assets/
+!bin/
+!demodata.json
+!manage.py
+!package.json
+!poetry.lock
+!procurement_portal
+!pyproject.toml
+!yarn.lock


### PR DESCRIPTION
Pros:
- This simplifies things vs a block list of ignored files/directories,
  since a block list means we'd have to add all editor files and other
  random things. This mainly only affects dev though, since most random
  files and directories won't exist in CI, so it's not really necessary.

Cons:
- This is annoying cuz now people have to remember to add new
  root files/directories.